### PR TITLE
Refactor process state and add unit tests

### DIFF
--- a/COMP2240/ASS1/run_tests.sh
+++ b/COMP2240/ASS1/run_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+mkdir -p build
+cp A1.java test/TestA1.java datafile1.txt build/
+cd build
+curl -s -L -o junit.jar https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
+curl -s -L -o hamcrest.jar https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
+javac -cp junit.jar:hamcrest.jar:. A1.java TestA1.java
+java -cp .:junit.jar:hamcrest.jar org.junit.runner.JUnitCore TestA1
+cd ..
+rm -rf build

--- a/COMP2240/ASS1/test/TestA1.java
+++ b/COMP2240/ASS1/test/TestA1.java
@@ -1,0 +1,36 @@
+import org.junit.Test;
+import static org.junit.Assert.*;
+import java.nio.file.*;
+import java.util.List;
+
+public class TestA1 {
+    private double avg(java.util.Map<String, Integer> map, List<A1.Proc> procs) {
+        long sum = 0;
+        for (A1.Proc p : procs)
+            sum += map.get(p.pid);
+        return procs.isEmpty() ? 0.0 : (double) sum / procs.size();
+    }
+
+    @Test
+    public void testParseRejectsDuplicatePid() throws Exception {
+        Path tmp = Files.createTempFile("dup", ".txt");
+        String content = "DISP: 0\nPID: p1\nArrTime: 0\nSrvTime: 1\nPID: p1\nArrTime: 1\nSrvTime: 1\n";
+        Files.writeString(tmp, content);
+        try {
+            A1.parse(tmp);
+            fail("Expected ParseException");
+        } catch (A1.ParseException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testRRAveragesMatchSample1() throws Exception {
+        A1.Input in = A1.parse(Path.of("datafile1.txt"));
+        A1.RunResult rr = A1.runRR(in, 3);
+        double avgTat = avg(rr.metrics.turnaround, in.procs);
+        double avgWait = avg(rr.metrics.waiting, in.procs);
+        assertEquals(15.20, avgTat, 0.01);
+        assertEquals(11.40, avgWait, 0.01);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract reusable `PState` class for shared process state across all schedulers.
- Tighten input parsing by rejecting duplicate PIDs and documenting core methods.
- Add JUnit tests covering duplicate PID handling and Round Robin averages.
- Inline `PState` into `A1.java` per review feedback.

## Testing
- `cd COMP2240/ASS1 && ./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ad36f312a08325a15619a755011a81